### PR TITLE
[feat] Photo 모듈 관련 1차 구현 (#12)

### DIFF
--- a/src/main/java/gdsc/cau/puangbe/common/util/ResponseCode.java
+++ b/src/main/java/gdsc/cau/puangbe/common/util/ResponseCode.java
@@ -27,12 +27,13 @@ public enum ResponseCode {
 
     // 409 Conflict
     USER_ALREADY_EXISTS(HttpStatus.CONFLICT, false, "이미 존재하는 사용자입니다."),
-    URL_ALREADY_UPLOADED(HttpStatus.CONFLICT, false, "이미 Url이 업로드 되었습니다."),
+    URL_ALREADY_UPLOADED(HttpStatus.CONFLICT, false, "이미 url이 업로드 되었습니다."),
 
     // 500 Internal Server Error
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, false, "서버에 오류가 발생하였습니다."),
 
     // 200 OK
+    PHOTORESULT_URL_FOUND(HttpStatus.OK, true, "image url 조회 성공"),
 
 
     // 201 Created

--- a/src/main/java/gdsc/cau/puangbe/common/util/ResponseCode.java
+++ b/src/main/java/gdsc/cau/puangbe/common/util/ResponseCode.java
@@ -20,12 +20,14 @@ public enum ResponseCode {
 
     // 404 Not Found
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, false, "사용자를 찾을 수 없습니다."),
+    PHOTORESULT_NOT_FOUND(HttpStatus.NOT_FOUND, false, "이미지 객체를 찾을 수 없습니다."),
 
     // 405 Method Not Allowed
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, false, "허용되지 않은 메서드입니다."),
 
     // 409 Conflict
     USER_ALREADY_EXISTS(HttpStatus.CONFLICT, false, "이미 존재하는 사용자입니다."),
+    URL_ALREADY_UPLOADED(HttpStatus.CONFLICT, false, "이미 Url이 업로드 되었습니다."),
 
     // 500 Internal Server Error
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, false, "서버에 오류가 발생하였습니다."),
@@ -35,7 +37,8 @@ public enum ResponseCode {
 
     // 201 Created
     USER_CREATE_SUCCESS(HttpStatus.CREATED, true, "사용자 생성 성공"),
-    PHOTORESULT_CREATE_SUCCESS(HttpStatus.CREATED, true, "PhotoResult 생성 성공");
+    PHOTORESULT_CREATE_SUCCESS(HttpStatus.CREATED, true, "PhotoResult 생성 성공"),
+    PHOTORESULT_URL_UPLOADED(HttpStatus.CREATED, true, "PhotoResult url 업로드 성공");
 
     private final HttpStatus httpStatus;
     private final Boolean success;

--- a/src/main/java/gdsc/cau/puangbe/common/util/ResponseCode.java
+++ b/src/main/java/gdsc/cau/puangbe/common/util/ResponseCode.java
@@ -34,7 +34,8 @@ public enum ResponseCode {
 
 
     // 201 Created
-    USER_CREATE_SUCCESS(HttpStatus.CREATED, true, "사용자 생성 성공");
+    USER_CREATE_SUCCESS(HttpStatus.CREATED, true, "사용자 생성 성공"),
+    PHOTORESULT_CREATE_SUCCESS(HttpStatus.CREATED, true, "PhotoResult 생성 성공");
 
     private final HttpStatus httpStatus;
     private final Boolean success;

--- a/src/main/java/gdsc/cau/puangbe/common/util/ResponseCode.java
+++ b/src/main/java/gdsc/cau/puangbe/common/util/ResponseCode.java
@@ -20,6 +20,7 @@ public enum ResponseCode {
 
     // 404 Not Found
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, false, "사용자를 찾을 수 없습니다."),
+    PHOTOREQUEST_NOT_FOUND(HttpStatus.NOT_FOUND, false, "요청 객체를 찾을 수 없습니다."),
     PHOTORESULT_NOT_FOUND(HttpStatus.NOT_FOUND, false, "이미지 객체를 찾을 수 없습니다."),
 
     // 405 Method Not Allowed

--- a/src/main/java/gdsc/cau/puangbe/photo/controller/PhotoController.java
+++ b/src/main/java/gdsc/cau/puangbe/photo/controller/PhotoController.java
@@ -22,4 +22,11 @@ public class PhotoController {
         return ApiResponse.success(photoService.uploadPhoto(photoResultId, imageUrl), ResponseCode.PHOTORESULT_URL_UPLOADED.getMessage());
     }
 
+    // TODO : 이메일 발송 관련 api 추가
+
+    @GetMapping("/{imageId}")
+    public ApiResponse<String> getImage(Long photoRequestId) {
+        return ApiResponse.success(photoService.get(photoRequestId), ResponseCode.PHOTORESULT_URL_FOUND.getMessage());
+    }
+
 }

--- a/src/main/java/gdsc/cau/puangbe/photo/controller/PhotoController.java
+++ b/src/main/java/gdsc/cau/puangbe/photo/controller/PhotoController.java
@@ -26,7 +26,7 @@ public class PhotoController {
 
     @GetMapping("/{imageId}")
     public ApiResponse<String> getImage(Long photoRequestId) {
-        return ApiResponse.success(photoService.get(photoRequestId), ResponseCode.PHOTORESULT_URL_FOUND.getMessage());
+        return ApiResponse.success(photoService.getPhotoUrl(photoRequestId), ResponseCode.PHOTORESULT_URL_FOUND.getMessage());
     }
 
 }

--- a/src/main/java/gdsc/cau/puangbe/photo/controller/PhotoController.java
+++ b/src/main/java/gdsc/cau/puangbe/photo/controller/PhotoController.java
@@ -1,0 +1,20 @@
+package gdsc.cau.puangbe.photo.controller;
+
+import gdsc.cau.puangbe.common.util.ApiResponse;
+import gdsc.cau.puangbe.common.util.ResponseCode;
+import gdsc.cau.puangbe.photo.service.PhotoService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/photo")
+public class PhotoController {
+    private final PhotoService photoService;
+
+    @PostMapping("/request")
+    public ApiResponse<Long> createUploadRequest(Long photoRequestId) {
+        return ApiResponse.success(photoService.createPhoto(photoRequestId), ResponseCode.PHOTORESULT_CREATE_SUCCESS.getMessage());
+    }
+
+}

--- a/src/main/java/gdsc/cau/puangbe/photo/controller/PhotoController.java
+++ b/src/main/java/gdsc/cau/puangbe/photo/controller/PhotoController.java
@@ -17,4 +17,9 @@ public class PhotoController {
         return ApiResponse.success(photoService.createPhoto(photoRequestId), ResponseCode.PHOTORESULT_CREATE_SUCCESS.getMessage());
     }
 
+    @PostMapping("/url")
+    public ApiResponse<Void> uploadImage(Long photoResultId, String imageUrl) {
+        return ApiResponse.success(photoService.uploadPhoto(photoResultId, imageUrl), ResponseCode.PHOTORESULT_URL_UPLOADED.getMessage());
+    }
+
 }

--- a/src/main/java/gdsc/cau/puangbe/photo/controller/PhotoController.java
+++ b/src/main/java/gdsc/cau/puangbe/photo/controller/PhotoController.java
@@ -2,6 +2,7 @@ package gdsc.cau.puangbe.photo.controller;
 
 import gdsc.cau.puangbe.common.util.ApiResponse;
 import gdsc.cau.puangbe.common.util.ResponseCode;
+import gdsc.cau.puangbe.photo.dto.request.UploadImageDto;
 import gdsc.cau.puangbe.photo.service.PhotoService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -12,20 +13,20 @@ import org.springframework.web.bind.annotation.*;
 public class PhotoController {
     private final PhotoService photoService;
 
-    @PostMapping("/request")
-    public ApiResponse<Long> createUploadRequest(Long photoRequestId) {
+    @PostMapping("/{photoRequestId}")
+    public ApiResponse<Long> createUploadRequest(@PathVariable Long photoRequestId) {
         return ApiResponse.success(photoService.createPhoto(photoRequestId), ResponseCode.PHOTORESULT_CREATE_SUCCESS.getMessage());
     }
 
     @PostMapping("/url")
-    public ApiResponse<Void> uploadImage(Long photoResultId, String imageUrl) {
-        return ApiResponse.success(photoService.uploadPhoto(photoResultId, imageUrl), ResponseCode.PHOTORESULT_URL_UPLOADED.getMessage());
+    public ApiResponse<Void> uploadImage(@RequestBody UploadImageDto uploadImageDto) {
+        return ApiResponse.success(photoService.uploadPhoto(uploadImageDto.getPhotoResultId(), uploadImageDto.getImageUrl()), ResponseCode.PHOTORESULT_URL_UPLOADED.getMessage());
     }
 
     // TODO : 이메일 발송 관련 api 추가
 
     @GetMapping("/{imageId}")
-    public ApiResponse<String> getImage(Long photoRequestId) {
+    public ApiResponse<String> getImage(@PathVariable("imageId") Long photoRequestId) {
         return ApiResponse.success(photoService.getPhotoUrl(photoRequestId), ResponseCode.PHOTORESULT_URL_FOUND.getMessage());
     }
 

--- a/src/main/java/gdsc/cau/puangbe/photo/dto/request/UploadImageDto.java
+++ b/src/main/java/gdsc/cau/puangbe/photo/dto/request/UploadImageDto.java
@@ -1,0 +1,11 @@
+package gdsc.cau.puangbe.photo.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UploadImageDto {
+    Long photoResultId;
+    String imageUrl;
+}

--- a/src/main/java/gdsc/cau/puangbe/photo/entity/PhotoResult.java
+++ b/src/main/java/gdsc/cau/puangbe/photo/entity/PhotoResult.java
@@ -30,10 +30,14 @@ public class PhotoResult {
     private String imageUrl; //s3에 저장된 AI결과 이미지 url
 
     @Builder
-    public PhotoResult(User user, PhotoRequest photoRequest, LocalDateTime createDate, String imageUrl){
+    public PhotoResult(User user, PhotoRequest photoRequest, LocalDateTime createDate){
         this.user = user;
         this.photoRequest = photoRequest;
         this.createDate = createDate;
+
+    }
+
+    public void update(String imageUrl){
         this.imageUrl = imageUrl;
     }
 }

--- a/src/main/java/gdsc/cau/puangbe/photo/entity/PhotoResult.java
+++ b/src/main/java/gdsc/cau/puangbe/photo/entity/PhotoResult.java
@@ -2,12 +2,14 @@ package gdsc.cau.puangbe.photo.entity;
 
 import gdsc.cau.puangbe.user.entity.User;
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
-
+import lombok.NoArgsConstructor;
 import java.time.LocalDateTime;
 
 @Entity
 @Getter
+@NoArgsConstructor
 public class PhotoResult {
 
     @Id
@@ -26,4 +28,12 @@ public class PhotoResult {
     private LocalDateTime createDate;
 
     private String imageUrl; //s3에 저장된 AI결과 이미지 url
+
+    @Builder
+    public PhotoResult(User user, PhotoRequest photoRequest, LocalDateTime createDate, String imageUrl){
+        this.user = user;
+        this.photoRequest = photoRequest;
+        this.createDate = createDate;
+        this.imageUrl = imageUrl;
+    }
 }

--- a/src/main/java/gdsc/cau/puangbe/photo/entity/PhotoResult.java
+++ b/src/main/java/gdsc/cau/puangbe/photo/entity/PhotoResult.java
@@ -2,6 +2,7 @@ package gdsc.cau.puangbe.photo.entity;
 
 import gdsc.cau.puangbe.user.entity.User;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,7 +10,7 @@ import java.time.LocalDateTime;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PhotoResult {
 
     @Id

--- a/src/main/java/gdsc/cau/puangbe/photo/repository/PhotoRepository.java
+++ b/src/main/java/gdsc/cau/puangbe/photo/repository/PhotoRepository.java
@@ -1,0 +1,9 @@
+package gdsc.cau.puangbe.photo.repository;
+
+import gdsc.cau.puangbe.photo.entity.PhotoResult;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PhotoRepository extends JpaRepository<PhotoResult, Long> {
+}

--- a/src/main/java/gdsc/cau/puangbe/photo/repository/PhotoRequestRepository.java
+++ b/src/main/java/gdsc/cau/puangbe/photo/repository/PhotoRequestRepository.java
@@ -1,0 +1,13 @@
+package gdsc.cau.puangbe.photo.repository;
+
+import gdsc.cau.puangbe.photo.entity.PhotoRequest;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+
+@Repository
+public interface PhotoRequestRepository extends JpaRepository<PhotoRequest, Long> {
+    Optional<PhotoRequest> findById(Long photoRequestId);
+}

--- a/src/main/java/gdsc/cau/puangbe/photo/repository/PhotoResultRepository.java
+++ b/src/main/java/gdsc/cau/puangbe/photo/repository/PhotoResultRepository.java
@@ -4,6 +4,9 @@ import gdsc.cau.puangbe.photo.entity.PhotoResult;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
-public interface PhotoRepository extends JpaRepository<PhotoResult, Long> {
+public interface PhotoResultRepository extends JpaRepository<PhotoResult, Long> {
+    Optional<PhotoResult> findById(Long photoResultId);
 }

--- a/src/main/java/gdsc/cau/puangbe/photo/repository/PhotoResultRepository.java
+++ b/src/main/java/gdsc/cau/puangbe/photo/repository/PhotoResultRepository.java
@@ -9,4 +9,6 @@ import java.util.Optional;
 @Repository
 public interface PhotoResultRepository extends JpaRepository<PhotoResult, Long> {
     Optional<PhotoResult> findById(Long photoResultId);
+
+    Optional<PhotoResult> findByPhotoRequestId(Long photoRequestId);
 }

--- a/src/main/java/gdsc/cau/puangbe/photo/service/PhotoService.java
+++ b/src/main/java/gdsc/cau/puangbe/photo/service/PhotoService.java
@@ -3,4 +3,5 @@ package gdsc.cau.puangbe.photo.service;
 public interface PhotoService {
     Long createPhoto(Long photoRequestId);
     Void uploadPhoto(Long photoResultId, String imageUrl);
+    String get(Long photoRequestId);
 }

--- a/src/main/java/gdsc/cau/puangbe/photo/service/PhotoService.java
+++ b/src/main/java/gdsc/cau/puangbe/photo/service/PhotoService.java
@@ -3,5 +3,5 @@ package gdsc.cau.puangbe.photo.service;
 public interface PhotoService {
     Long createPhoto(Long photoRequestId);
     Void uploadPhoto(Long photoResultId, String imageUrl);
-    String get(Long photoRequestId);
+    String getPhotoUrl(Long photoRequestId);
 }

--- a/src/main/java/gdsc/cau/puangbe/photo/service/PhotoService.java
+++ b/src/main/java/gdsc/cau/puangbe/photo/service/PhotoService.java
@@ -1,0 +1,5 @@
+package gdsc.cau.puangbe.photo.service;
+
+public interface PhotoService {
+    Long createPhoto(Long photoRequestId);
+}

--- a/src/main/java/gdsc/cau/puangbe/photo/service/PhotoService.java
+++ b/src/main/java/gdsc/cau/puangbe/photo/service/PhotoService.java
@@ -2,4 +2,5 @@ package gdsc.cau.puangbe.photo.service;
 
 public interface PhotoService {
     Long createPhoto(Long photoRequestId);
+    Void uploadPhoto(Long photoResultId, String imageUrl);
 }

--- a/src/main/java/gdsc/cau/puangbe/photo/service/PhotoServiceImpl.java
+++ b/src/main/java/gdsc/cau/puangbe/photo/service/PhotoServiceImpl.java
@@ -45,15 +45,15 @@ public class PhotoServiceImpl implements PhotoService {
     @Transactional
     public Void uploadPhoto(Long photoResultId,String imageUrl) {
         Optional<PhotoResult> photoResult = photoResultRepository.findById(photoResultId);
-        if(photoResult.isPresent()){
-            Optional<PhotoRequest> photoRequest = photoRequestRepository.findById(photoResult.get().getPhotoRequest().getId());
-            if(photoRequest.isPresent()){
-                if (photoRequest.get().getStatus() == RequestStatus.FINISHED) {
-                    throw new BaseException(ResponseCode.URL_ALREADY_UPLOADED);
-                }
-            }
-        } else {
+        if(!photoResult.isPresent()){
             throw new BaseException(ResponseCode.PHOTORESULT_NOT_FOUND);
+        }
+
+        Optional<PhotoRequest> photoRequest = photoRequestRepository.findById(photoResult.get().getPhotoRequest().getId());
+        if(photoRequest.isPresent()){
+            if (photoRequest.get().getStatus() == RequestStatus.FINISHED) {
+                throw new BaseException(ResponseCode.URL_ALREADY_UPLOADED);
+            }
         }
 
         photoResult.get().update(imageUrl);

--- a/src/main/java/gdsc/cau/puangbe/photo/service/PhotoServiceImpl.java
+++ b/src/main/java/gdsc/cau/puangbe/photo/service/PhotoServiceImpl.java
@@ -46,7 +46,7 @@ public class PhotoServiceImpl implements PhotoService {
                 .orElseThrow(() -> new BaseException(ResponseCode.PHOTORESULT_NOT_FOUND));
 
         PhotoRequest photoRequest = photoRequestRepository.findById(photoResult.getPhotoRequest().getId())
-                .orElseThrow(() -> new BaseException(ResponseCode.PHOTORESULT_NOT_FOUND));
+                .orElseThrow(() -> new BaseException(ResponseCode.PHOTOREQUEST_NOT_FOUND));
 
         if (photoRequest.getStatus() == RequestStatus.FINISHED) {
             throw new BaseException(ResponseCode.URL_ALREADY_UPLOADED);

--- a/src/main/java/gdsc/cau/puangbe/photo/service/PhotoServiceImpl.java
+++ b/src/main/java/gdsc/cau/puangbe/photo/service/PhotoServiceImpl.java
@@ -27,19 +27,18 @@ public class PhotoServiceImpl implements PhotoService {
     public Long createPhoto(Long photoRequestId) {
         Optional<PhotoRequest> photoRequest = photoRequestRepository.findById(photoRequestId);
 
-        if(photoRequest.isPresent()){
-            PhotoResult photoResult = PhotoResult.builder()
-                    .user(photoRequest.get().getUser())
-                    .photoRequest(photoRequest.get())
-                    .createDate(LocalDateTime.now())
-                    .build();
-
-            // TODO: api호출 주체에서 photoRequest의 photoResult 부분도 업데이트
-
-           return photoResultRepository.save(photoResult).getId();
-        } else {
+        if(!photoRequest.isPresent()){
             throw new BaseException(ResponseCode.BAD_REQUEST);
         }
+        PhotoResult photoResult = PhotoResult.builder()
+                .user(photoRequest.get().getUser())
+                .photoRequest(photoRequest.get())
+                .createDate(LocalDateTime.now())
+                .build();
+
+        // TODO: api호출 주체에서 photoRequest의 photoResult 부분도 업데이트
+
+        return photoResultRepository.save(photoResult).getId();
     }
 
     @Override

--- a/src/main/java/gdsc/cau/puangbe/photo/service/PhotoServiceImpl.java
+++ b/src/main/java/gdsc/cau/puangbe/photo/service/PhotoServiceImpl.java
@@ -1,0 +1,43 @@
+package gdsc.cau.puangbe.photo.service;
+
+import gdsc.cau.puangbe.common.exception.BaseException;
+import gdsc.cau.puangbe.common.util.ResponseCode;
+import gdsc.cau.puangbe.photo.entity.PhotoRequest;
+import gdsc.cau.puangbe.photo.entity.PhotoResult;
+import gdsc.cau.puangbe.photo.repository.PhotoRepository;
+import gdsc.cau.puangbe.photo.repository.PhotoRequestRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PhotoServiceImpl implements PhotoService {
+    private final PhotoRepository photoRepository;
+    private final PhotoRequestRepository photoRequestRepository;
+
+    @Override
+    @Transactional
+    public Long createPhoto(Long photoRequestId) {
+        Optional<PhotoRequest> photoRequest = photoRequestRepository.findById(photoRequestId);
+
+        if(photoRequest.isPresent()){
+            PhotoResult photoResult = PhotoResult.builder()
+                    .user(photoRequest.get().getUser())
+                    .photoRequest(photoRequest.get())
+                    .createDate(LocalDateTime.now())
+                    .build();
+
+            // TODO: photoRequest도 업데이트 (비지니스 로직 builder 패턴으로 할지 상의 후 추가 작성 - 다른 위치에)
+
+           return photoRepository.save(photoResult).getId();
+        } else {
+            throw new BaseException(ResponseCode.BAD_REQUEST);
+        }
+    }
+}

--- a/src/main/java/gdsc/cau/puangbe/photo/service/PhotoServiceImpl.java
+++ b/src/main/java/gdsc/cau/puangbe/photo/service/PhotoServiceImpl.java
@@ -58,9 +58,18 @@ public class PhotoServiceImpl implements PhotoService {
         }
 
         photoResult.get().update(imageUrl);
-        
+
         // TODO : url 업로드 하고 PhotoRequest의 status 업데이트 (어느 메서드에서 할지 논의)
 
         return null;
     }
+
+    public String get(Long photoRequestId) {
+        Optional<PhotoResult> photoResult = photoResultRepository.findByPhotoRequestId(photoRequestId);
+        if(!photoResult.isPresent()){
+            throw new BaseException(ResponseCode.PHOTORESULT_NOT_FOUND);
+        }
+        return photoResult.get().getImageUrl();
+    }
+
 }


### PR DESCRIPTION
# #️⃣ 연관 이슈

> #12 

# 📝 작업 내용

> Photo 모듈 api 로직 작성하였습니다.
>
> 이미지 생성 전 photo 객체 생성하는 api
> 이미지 생성 후 url 저장하고, photo 객체 업데이트 api
> requestId로 접근해서 imageUrl을 전송하는 api


## 참고 이미지 및 자료
> 

# 💬 리뷰 요구사항

> 규칙에 맞지 않는 부분이 보이거나 생각과 다르게 구현된 부분이 있다면 말씀해주시면 좋을 것 같습니다!
>
>관심사 분리 목적으로 인해 PhotoRequest 제외하고 PhotoResult 부분만 생성, 수정하도록 작성하였습니다. 주석으로 TODO 작성한 부분 보시고 저와 같은 생각이신지 리뷰 달아주시면 감사하겠습니다.
>
> 윤진님과 상의 후 일단 파이썬에서 s3에 저장한 url이 넘어온다고 가정하고 메서드 작성하였습니다. 추후에 multipart file로 넘어오는 것으로 결정되면 해당 부분 수정하겠습니다.
>
> 지우님과 상의 후 entity 관련해서 builder 패턴을 사용하기로 했는데, 작성 코드 보시고 생성자로 변경이 필요해보이면 리뷰 달아주시면 감사하겠습니다. 
>
> user, request 부분은 제가 임의로 제 로컬 db에 데이터를 넣고 테스트 해보았습니다. 추후에 해당 모듈 코드 작성 후에 제 코드도 수정 필요하면 말씀해주세용