### PR TITLE
[feat] 카카오 로그인 및 JWT 구현 (#6)

### DIFF
--- a/.gradle/buildOutputCleanup/cache.properties
+++ b/.gradle/buildOutputCleanup/cache.properties
@@ -1,2 +1,2 @@
-#Sun Jul 07 23:41:51 KST 2024
+#Sat Aug 03 21:35:13 KST 2024
 gradle.version=8.8

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,17 @@ dependencies {
 
 	// swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+
+	// JWT
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+
+	// WebClient
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+	// Local Cache
+	implementation 'org.springframework.boot:spring-boot-starter-cache'
 }
 
 tasks.named('test') {

--- a/src/main/java/gdsc/cau/puangbe/PuangbeApplication.java
+++ b/src/main/java/gdsc/cau/puangbe/PuangbeApplication.java
@@ -2,8 +2,10 @@ package gdsc.cau.puangbe;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 @SpringBootApplication
+@ConfigurationPropertiesScan
 public class PuangbeApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/gdsc/cau/puangbe/auth/config/CacheConfig.java
+++ b/src/main/java/gdsc/cau/puangbe/auth/config/CacheConfig.java
@@ -1,0 +1,17 @@
+package gdsc.cau.puangbe.auth.config;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+  @Bean
+  public CacheManager cacheManager() {
+    return new ConcurrentMapCacheManager("kakaoPublicKeyList");
+  }
+
+}

--- a/src/main/java/gdsc/cau/puangbe/auth/config/JwtProperties.java
+++ b/src/main/java/gdsc/cau/puangbe/auth/config/JwtProperties.java
@@ -1,0 +1,14 @@
+package gdsc.cau.puangbe.auth.config;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@ConfigurationProperties( prefix = "jwt")
+@RequiredArgsConstructor
+public class JwtProperties {
+  private final String secretKey;
+  private final Long accessTokenValidityInSeconds;
+  private final Long refreshTokenValidityInSeconds;
+}

--- a/src/main/java/gdsc/cau/puangbe/auth/config/KakaoLoginProperties.java
+++ b/src/main/java/gdsc/cau/puangbe/auth/config/KakaoLoginProperties.java
@@ -1,0 +1,17 @@
+package gdsc.cau.puangbe.auth.config;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@ConfigurationProperties( prefix = "oauth2.kakao")
+@RequiredArgsConstructor
+public class KakaoLoginProperties {
+  private final String clientId;
+  private final String clientSecret;
+  private final String redirectUri;
+  private final String tokenUri;
+  private final String metadataUri;
+  private final String publicKeyUri;
+}

--- a/src/main/java/gdsc/cau/puangbe/auth/controller/AuthController.java
+++ b/src/main/java/gdsc/cau/puangbe/auth/controller/AuthController.java
@@ -1,0 +1,30 @@
+package gdsc.cau.puangbe.auth.controller;
+
+import gdsc.cau.puangbe.auth.dto.LoginResponse;
+import gdsc.cau.puangbe.auth.dto.ReissueResponse;
+import gdsc.cau.puangbe.auth.service.AuthService;
+import gdsc.cau.puangbe.common.util.ApiResponse;
+import gdsc.cau.puangbe.common.util.ResponseCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class AuthController {
+  private final AuthService authService;
+
+  @GetMapping("/login/oauth/kakao")
+  public ApiResponse<LoginResponse> loginWithKakao(@RequestParam("code") String code) {
+    return ApiResponse.success(authService.loginWithKakao(code), ResponseCode.USER_LOGIN_SUCCESS.getMessage());
+  }
+
+  @GetMapping("/reissue")
+  public ApiResponse<ReissueResponse> reissue(@RequestHeader(value = "Authorization", required = false) String authorizationHeader) {
+    return ApiResponse.success(authService.reissue(authorizationHeader), ResponseCode.USER_TOKEN_REISSUE_SUCCESS.getMessage());
+  }
+}

--- a/src/main/java/gdsc/cau/puangbe/auth/dto/AuthPayload.java
+++ b/src/main/java/gdsc/cau/puangbe/auth/dto/AuthPayload.java
@@ -1,0 +1,18 @@
+package gdsc.cau.puangbe.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AuthPayload {
+  private String aud;
+  private String sub;
+  private String iss;
+  private Long exp;
+  private String nickname;
+}

--- a/src/main/java/gdsc/cau/puangbe/auth/dto/KakaoIdTokenPublicKey.java
+++ b/src/main/java/gdsc/cau/puangbe/auth/dto/KakaoIdTokenPublicKey.java
@@ -1,0 +1,13 @@
+package gdsc.cau.puangbe.auth.dto;
+
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class KakaoIdTokenPublicKey {
+  private List<KakaoJWK> keys;
+}

--- a/src/main/java/gdsc/cau/puangbe/auth/dto/KakaoJWK.java
+++ b/src/main/java/gdsc/cau/puangbe/auth/dto/KakaoJWK.java
@@ -1,0 +1,22 @@
+package gdsc.cau.puangbe.auth.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class KakaoJWK {
+  private String kid;
+
+  private String kty;
+
+  private String alg;
+
+  private String use;
+
+  private String n;
+
+  private String e;
+}

--- a/src/main/java/gdsc/cau/puangbe/auth/dto/LoginResponse.java
+++ b/src/main/java/gdsc/cau/puangbe/auth/dto/LoginResponse.java
@@ -1,0 +1,12 @@
+package gdsc.cau.puangbe.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class LoginResponse {
+  private String accessToken;
+}

--- a/src/main/java/gdsc/cau/puangbe/auth/dto/OAuthTokenResponse.java
+++ b/src/main/java/gdsc/cau/puangbe/auth/dto/OAuthTokenResponse.java
@@ -1,0 +1,31 @@
+package gdsc.cau.puangbe.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class OAuthTokenResponse {
+  @JsonProperty("token_type")
+  private String tokenType;
+
+  @JsonProperty("access_token")
+  private String accessToken;
+
+  @JsonProperty("id_token")
+  private String idToken;
+
+  @JsonProperty("expires_in")
+  private Integer expiresIn;
+
+  @JsonProperty("refresh_token")
+  private String refreshToken;
+
+  @JsonProperty("refresh_token_expires_in")
+  private Integer refreshTokenExpiresIn;
+
+  private String scope;
+}

--- a/src/main/java/gdsc/cau/puangbe/auth/dto/ReissueResponse.java
+++ b/src/main/java/gdsc/cau/puangbe/auth/dto/ReissueResponse.java
@@ -1,0 +1,12 @@
+package gdsc.cau.puangbe.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class ReissueResponse {
+  private String accessToken;
+}

--- a/src/main/java/gdsc/cau/puangbe/auth/entity/Token.java
+++ b/src/main/java/gdsc/cau/puangbe/auth/entity/Token.java
@@ -1,0 +1,41 @@
+package gdsc.cau.puangbe.auth.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Token {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "refresh_token_id")
+  private Long id;
+
+  private String refreshToken;
+
+  private String kakaoId;
+
+  private LocalDateTime expiresAt;
+
+  @Builder
+  public Token(String refreshToken, String kakaoId, LocalDateTime expiresAt){
+    this.refreshToken = refreshToken;
+    this.kakaoId = kakaoId;
+    this.expiresAt = expiresAt;
+  }
+
+  public void update(String refreshToken, LocalDateTime expiresAt) {
+    this.refreshToken = refreshToken;
+    this.expiresAt = expiresAt;
+  }
+}

--- a/src/main/java/gdsc/cau/puangbe/auth/exception/AuthException.java
+++ b/src/main/java/gdsc/cau/puangbe/auth/exception/AuthException.java
@@ -1,0 +1,11 @@
+package gdsc.cau.puangbe.auth.exception;
+
+import gdsc.cau.puangbe.common.exception.BaseException;
+import gdsc.cau.puangbe.common.util.ResponseCode;
+
+public class AuthException extends BaseException {
+
+  public AuthException(ResponseCode responseCode) {
+    super(responseCode);
+  }
+}

--- a/src/main/java/gdsc/cau/puangbe/auth/external/JwtProvider.java
+++ b/src/main/java/gdsc/cau/puangbe/auth/external/JwtProvider.java
@@ -1,0 +1,143 @@
+package gdsc.cau.puangbe.auth.external;
+
+import gdsc.cau.puangbe.auth.config.JwtProperties;
+import gdsc.cau.puangbe.auth.exception.AuthException;
+import gdsc.cau.puangbe.common.util.ResponseCode;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SecurityException;
+import java.security.Key;
+import java.util.Date;
+import javax.crypto.SecretKey;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class JwtProvider implements InitializingBean {
+  private final JwtProperties jwtProperties;
+  private Key secretkey;
+  private final String ISS = "http://www.puangfilm.com";
+
+  @Override
+  public void afterPropertiesSet() {
+    byte[] secretKeyBytes = Decoders.BASE64.decode(jwtProperties.getSecretKey());
+    this.secretkey = Keys.hmacShaKeyFor(secretKeyBytes);
+  }
+
+  public String createAccessToken(String kakaoId, Long refreshId) {
+    Date now = new Date();
+    Date expiration = new Date(now.getTime() + jwtProperties.getAccessTokenValidityInSeconds() * 1000);
+
+    return Jwts.builder()
+        .issuer(ISS) // 토큰을 발급한 인증 기관 정보
+        .subject(kakaoId) // 토큰에 해당하는 사용자의 kakao_id
+        .issuedAt(now) // 토큰 발급 또는 갱신 시각
+        .expiration(expiration) // 토큰 만료 시간
+        .claim("refreshId", refreshId)
+        .signWith(secretkey)
+        .compact();
+  }
+
+  public String createRefreshToken(String kakaoId, String userName) {
+    Date now = new Date();
+    Date expiration = new Date(now.getTime() + + jwtProperties.getRefreshTokenValidityInSeconds() * 1000);
+
+    return Jwts.builder()
+        .issuer(ISS) // 토큰을 발급한 인증 기관 정보
+        .subject(kakaoId) // 토큰에 해당하는 사용자의 kakao_id
+        .issuedAt(now) // 토큰 발급 또는 갱신 시각
+        .expiration(expiration) // 토큰 만료 시간
+        .claim("userName", userName)
+        .signWith(secretkey)
+        .compact();
+  }
+
+  public void validateToken(String token) {
+    try {
+      Jwts.parser()
+          .verifyWith((SecretKey) secretkey)
+          .build()
+          .parseSignedClaims(token);
+    } catch (SecurityException | MalformedJwtException e) {
+      throw new AuthException(ResponseCode.UNAUTHORIZED); // 잘못된 서명
+    } catch (ExpiredJwtException e) {
+      throw new AuthException(ResponseCode.UNAUTHORIZED); // 만료
+    } catch (UnsupportedJwtException e) {
+      throw new AuthException(ResponseCode.UNAUTHORIZED); // 지원되지 않는 토큰
+    } catch (IllegalArgumentException e) {
+      throw new AuthException(ResponseCode.BAD_REQUEST); // 잘못된 토큰
+    }
+  }
+
+  public String getKakaoIdFromToken(String token) {
+    return Jwts.parser()
+        .verifyWith((SecretKey) secretkey)
+        .build()
+        .parseSignedClaims(token)
+        .getPayload()
+        .getSubject(); // 토큰에 해당하는 사용자의 kakao_id
+  }
+
+  public String getUserNameFromRefreshToken(String token) {
+    return Jwts.parser()
+        .verifyWith((SecretKey) secretkey)
+        .build()
+        .parseSignedClaims(token)
+        .getPayload()
+        .get("userName", String.class); // 토큰에 해당하는 사용자의 kakao_id
+  }
+
+  public Date getExpirationFromToken(String token) {
+    return Jwts.parser()
+        .verifyWith((SecretKey) secretkey)
+        .build()
+        .parseSignedClaims(token)
+        .getPayload()
+        .getExpiration();
+  }
+
+  public String getKakaoIdFromExpiredToken(String token) {
+    try {
+      return Jwts.parser()
+          .verifyWith((SecretKey) secretkey)
+          .build()
+          .parseSignedClaims(token)
+          .getPayload()
+          .getSubject(); // 토큰에 해당하는 사용자의 kakao_id
+    } catch (ExpiredJwtException e) {
+      return e.getClaims().getSubject();
+    }
+  }
+
+  public Long getRefreshIdFromExpiredToken(String token) {
+    try {
+      return Jwts.parser()
+          .verifyWith((SecretKey) secretkey)
+          .build()
+          .parseSignedClaims(token)
+          .getPayload()
+          .get("refreshId", Long.class);
+    } catch (ExpiredJwtException e) {
+      return e.getClaims().get("refreshId", Long.class);
+    }
+  }
+
+  public String reissueAccessToken(String refreshToken, Long refreshId) {
+    validateToken(refreshToken);
+    return createAccessToken(getKakaoIdFromToken(refreshToken), refreshId);
+  }
+
+  public String getTokenFromAuthorizationHeader(String authorizationHeader) {
+    if (authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
+      return authorizationHeader.substring(7);
+    }
+    throw new AuthException(ResponseCode.BAD_REQUEST);
+  }
+
+}

--- a/src/main/java/gdsc/cau/puangbe/auth/external/KakaoProvider.java
+++ b/src/main/java/gdsc/cau/puangbe/auth/external/KakaoProvider.java
@@ -1,0 +1,57 @@
+package gdsc.cau.puangbe.auth.external;
+
+import gdsc.cau.puangbe.auth.config.KakaoLoginProperties;
+import gdsc.cau.puangbe.auth.dto.KakaoIdTokenPublicKey;
+import gdsc.cau.puangbe.auth.dto.OAuthTokenResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheConfig;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Component
+@RequiredArgsConstructor
+@CacheConfig(cacheNames = "kakaoPublicKeyList")
+public class KakaoProvider {
+  private final KakaoLoginProperties kakaoLoginProperties;
+
+  public OAuthTokenResponse getTokenByCode(String code) {
+    return WebClient.create()
+        .post()
+        .uri(kakaoLoginProperties.getTokenUri())
+        .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+        .body(BodyInserters.
+            fromFormData("grant_type", "authorization_code")
+            .with("client_id", kakaoLoginProperties.getClientId())
+            .with("redirect_uri", kakaoLoginProperties.getRedirectUri())
+            .with("code", code)
+            .with("client_secret", kakaoLoginProperties.getClientSecret()))
+        .retrieve()
+        .bodyToMono(OAuthTokenResponse.class)
+        .block();
+  }
+
+  @Cacheable(key = "'all'")
+  public KakaoIdTokenPublicKey getOIDCPublicKeyList() {
+    return WebClient.create()
+        .get()
+        .uri(kakaoLoginProperties.getPublicKeyUri())
+        .retrieve()
+        .bodyToMono(KakaoIdTokenPublicKey.class)
+        .block();
+  }
+
+  public KakaoIdTokenPublicKey getUpdatedOIDCPublicKeyList() {
+    return getOIDCPublicKeyList();
+  }
+
+  // 매일 새벽 5시에 실행
+  @Scheduled(cron = "0 0 5 * * ?") // 초 분 시 일 월 요일 (연도)
+  public void updateKakaoPublicKeyListCache() {
+    getOIDCPublicKeyList();
+  }
+}

--- a/src/main/java/gdsc/cau/puangbe/auth/external/OIDCProvider.java
+++ b/src/main/java/gdsc/cau/puangbe/auth/external/OIDCProvider.java
@@ -1,0 +1,126 @@
+package gdsc.cau.puangbe.auth.external;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import gdsc.cau.puangbe.auth.config.KakaoLoginProperties;
+import gdsc.cau.puangbe.auth.dto.AuthPayload;
+import gdsc.cau.puangbe.auth.dto.KakaoIdTokenPublicKey;
+import gdsc.cau.puangbe.auth.dto.KakaoJWK;
+import gdsc.cau.puangbe.auth.exception.AuthException;
+import gdsc.cau.puangbe.common.util.ResponseCode;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.SecurityException;
+import io.jsonwebtoken.security.SignatureException;
+import java.io.IOException;
+import java.math.BigInteger;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.RSAPublicKeySpec;
+import java.util.Base64;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class OIDCProvider {
+  private final KakaoLoginProperties kakaoLoginProperties;
+
+  public AuthPayload verify(String token, String iss, KakaoIdTokenPublicKey kakaoIdTokenPublicKey) {
+    verifyPayload(token, iss);
+    return verifySignature(token, kakaoIdTokenPublicKey);
+  }
+
+  private void verifyPayload(String token, String iss) {
+    AuthPayload authPayload = extractPayloadFromTokenString(token);
+
+    if (!authPayload.getIss().equals(iss)) {
+      throw new AuthException(ResponseCode.UNAUTHORIZED);
+    }
+    if (!authPayload.getAud().equals(kakaoLoginProperties.getClientId())) {
+      throw new AuthException(ResponseCode.UNAUTHORIZED);
+    }
+    if (authPayload.getExp().compareTo(System.currentTimeMillis() / 1000) < 0) {
+      throw new AuthException(ResponseCode.UNAUTHORIZED);
+    }
+  }
+
+  private AuthPayload extractPayloadFromTokenString(String token) {
+    String[] parts = token.split("\\.");
+    if (parts.length != 3) {
+      throw new AuthException(ResponseCode.BAD_REQUEST); // Invalid JWT token
+    }
+    byte[] payloadBytes = Base64.getUrlDecoder().decode(parts[1]);
+
+    try {
+      return new ObjectMapper().readValue(payloadBytes, AuthPayload.class);
+    } catch (IOException e) {
+      throw new AuthException(ResponseCode.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  private String extractHeaderKidFromTokenString(String token)  {
+    String[] parts = token.split("\\.");
+    if (parts.length != 3) {
+      throw new AuthException(ResponseCode.BAD_REQUEST); // Invalid JWT token
+    }
+
+    byte[] headerBytes = Base64.getUrlDecoder().decode(parts[0]);
+
+    try {
+      return new ObjectMapper().readTree(headerBytes).get("kid").asText();
+    } catch (IOException e) {
+      throw new AuthException(ResponseCode.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  private AuthPayload verifySignature(String token, KakaoIdTokenPublicKey kakaoIdTokenPublicKey) {
+    KakaoJWK kakaoJWK = getOIDCPublicKey(extractHeaderKidFromTokenString(token), kakaoIdTokenPublicKey);
+
+    Claims payload;
+    AuthPayload authPayload = new AuthPayload();
+    try {
+      payload = Jwts.parser()
+          .verifyWith(getRSAPublicKey(kakaoJWK))
+          .build()
+          .parseSignedClaims(token)
+          .getPayload();
+      authPayload.setSub(payload.getSubject());
+      authPayload.setNickname(payload.get("nickname").toString());
+      return authPayload;
+    } catch (SignatureException e) {
+      throw e;
+    } catch (SecurityException e) {
+      throw new AuthException(ResponseCode.UNAUTHORIZED);
+    }
+  }
+
+  private KakaoJWK getOIDCPublicKey(String kid, KakaoIdTokenPublicKey kakaoIdTokenPublicKey) {
+    return kakaoIdTokenPublicKey.getKeys().stream()
+        .filter(kakaoJWK -> kakaoJWK.getKid().equals(kid))
+        .findFirst()
+        .orElseThrow(() -> new AuthException(ResponseCode.BAD_REQUEST)); // 일치하는 PK 없음
+  }
+
+  private PublicKey getRSAPublicKey(KakaoJWK kakaoJWK) {
+    byte[] decodeN = Base64.getUrlDecoder().decode(kakaoJWK.getN());
+    byte[] decodeE = Base64.getUrlDecoder().decode(kakaoJWK.getE());
+    BigInteger n = new BigInteger(1, decodeN);
+    BigInteger e = new BigInteger(1, decodeE);
+
+    RSAPublicKeySpec rsaPublicKeySpec = new RSAPublicKeySpec(n, e);
+    KeyFactory keyFactory;
+    try {
+      keyFactory = KeyFactory.getInstance("RSA");
+    } catch (NoSuchAlgorithmException ex) {
+      throw new AuthException(ResponseCode.INTERNAL_SERVER_ERROR);
+    }
+
+    try {
+      return keyFactory.generatePublic(rsaPublicKeySpec);
+    } catch (InvalidKeySpecException ex) {
+      throw new AuthException(ResponseCode.INTERNAL_SERVER_ERROR);
+    }
+  }
+}

--- a/src/main/java/gdsc/cau/puangbe/auth/repository/TokenRepository.java
+++ b/src/main/java/gdsc/cau/puangbe/auth/repository/TokenRepository.java
@@ -1,0 +1,10 @@
+package gdsc.cau.puangbe.auth.repository;
+
+import gdsc.cau.puangbe.auth.entity.Token;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.transaction.annotation.Transactional;
+
+public interface TokenRepository extends JpaRepository<Token, Long> {
+  Optional<Token> findByKakaoId(String kakaoId);
+}

--- a/src/main/java/gdsc/cau/puangbe/auth/service/AuthService.java
+++ b/src/main/java/gdsc/cau/puangbe/auth/service/AuthService.java
@@ -1,0 +1,9 @@
+package gdsc.cau.puangbe.auth.service;
+
+import gdsc.cau.puangbe.auth.dto.LoginResponse;
+import gdsc.cau.puangbe.auth.dto.ReissueResponse;
+
+public interface AuthService {
+  LoginResponse loginWithKakao(String code);
+  ReissueResponse reissue(String authorizationHeader);
+}

--- a/src/main/java/gdsc/cau/puangbe/auth/service/AuthServiceImpl.java
+++ b/src/main/java/gdsc/cau/puangbe/auth/service/AuthServiceImpl.java
@@ -1,0 +1,92 @@
+package gdsc.cau.puangbe.auth.service;
+
+import gdsc.cau.puangbe.auth.dto.AuthPayload;
+import gdsc.cau.puangbe.auth.dto.OAuthTokenResponse;
+import gdsc.cau.puangbe.auth.dto.LoginResponse;
+import gdsc.cau.puangbe.auth.dto.ReissueResponse;
+import gdsc.cau.puangbe.auth.entity.Token;
+import gdsc.cau.puangbe.auth.exception.AuthException;
+import gdsc.cau.puangbe.auth.external.JwtProvider;
+import gdsc.cau.puangbe.auth.external.KakaoProvider;
+import gdsc.cau.puangbe.auth.external.OIDCProvider;
+import gdsc.cau.puangbe.auth.repository.TokenRepository;
+import gdsc.cau.puangbe.common.util.ResponseCode;
+import gdsc.cau.puangbe.user.repository.UserRepository;
+import gdsc.cau.puangbe.user.entity.User;
+import io.jsonwebtoken.security.SignatureException;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AuthServiceImpl implements AuthService {
+  private final TokenRepository tokenRepository;
+  private final UserRepository userRepository;
+
+  private final KakaoProvider kakaoProvider;
+  private final OIDCProvider OIDCProvider;
+  private final JwtProvider jwtProvider;
+
+  private final String ISS = "https://kauth.kakao.com";
+
+  @Override
+  public LoginResponse loginWithKakao(String code) {
+    // 카카오로부터 토큰 발급
+    OAuthTokenResponse kakaoToken = kakaoProvider.getTokenByCode(code);
+
+    // ID 토큰 유효성 검증
+    AuthPayload authPayload;
+    try {
+      authPayload = OIDCProvider.verify(kakaoToken.getIdToken(), ISS, kakaoProvider.getOIDCPublicKeyList());
+    } catch (SignatureException e) {
+      authPayload = OIDCProvider.verify(kakaoToken.getIdToken(), ISS, kakaoProvider.getUpdatedOIDCPublicKeyList());
+    }
+
+    final String kakaoId = authPayload.getSub();
+    final String userName = authPayload.getNickname();
+
+    // JWT 토큰 발행 및 DB 업데이트 (가입 완료 or 로그인)
+    String refreshTokenString = jwtProvider.createRefreshToken(kakaoId, userName);
+
+    userRepository.findByKakaoId(kakaoId)
+        .map(u -> {
+          u.updateRequestDate(LocalDateTime.now());
+          return userRepository.save(u);
+        })
+        .orElseGet(() -> userRepository.save(User.builder()
+            .userName(userName)
+            .createDate(LocalDateTime.now())
+            .requestDate(LocalDateTime.now())
+            .kakaoId(kakaoId)
+            .build()
+        ));
+
+    Token refreshToken = Token.builder()
+        .refreshToken(refreshTokenString)
+        .kakaoId(kakaoId)
+        .expiresAt(jwtProvider.getExpirationFromToken(refreshTokenString).toInstant().atZone(ZoneId.systemDefault()).toLocalDateTime())
+        .build();
+    Token savedRefreshToken = tokenRepository.save(refreshToken);
+    System.out.println(savedRefreshToken.getId());
+
+    String accessToken = jwtProvider.createAccessToken(authPayload.getSub(), savedRefreshToken.getId());
+
+    return new LoginResponse(accessToken);
+  }
+
+  @Override
+  public ReissueResponse reissue(String authorizationHeader) {
+    String accessToken = jwtProvider.getTokenFromAuthorizationHeader(authorizationHeader);
+
+    Long refreshTokenId = jwtProvider.getRefreshIdFromExpiredToken(accessToken);
+
+    Token refreshToken = tokenRepository.findById(refreshTokenId)
+        .orElseThrow(() -> new AuthException(ResponseCode.UNAUTHORIZED));
+
+    String newAccessToken = jwtProvider.reissueAccessToken(refreshToken.getRefreshToken(), refreshToken.getId());
+
+    return new ReissueResponse(newAccessToken);
+  }
+}

--- a/src/main/java/gdsc/cau/puangbe/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/gdsc/cau/puangbe/common/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package gdsc.cau.puangbe.common.exception;
 
+import gdsc.cau.puangbe.auth.exception.AuthException;
 import gdsc.cau.puangbe.common.util.ApiResponse;
 import gdsc.cau.puangbe.user.UserException;
 import lombok.extern.slf4j.Slf4j;
@@ -13,6 +14,12 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(UserException.class)
     public ApiResponse<Void> handleUserException(UserException e) {
         log.info("UserException: {}", e.getMessage());
+        return ApiResponse.fail(e.getResponseCode(), e.getMessage());
+    }
+
+    @ExceptionHandler(AuthException.class)
+    public ApiResponse<Void> handleAuthException(AuthException e) {
+        log.info("AuthException: {}", e.getMessage());
         return ApiResponse.fail(e.getResponseCode(), e.getMessage());
     }
 }

--- a/src/main/java/gdsc/cau/puangbe/common/util/ResponseCode.java
+++ b/src/main/java/gdsc/cau/puangbe/common/util/ResponseCode.java
@@ -17,6 +17,7 @@ public enum ResponseCode {
 
     // 403 Forbidden
     FORBIDDEN(HttpStatus.FORBIDDEN, false, "권한이 없습니다."),
+    REFRESH_TOKEN_EXPIRED(HttpStatus.FORBIDDEN, false, "리프레시 토큰이 만료되었습니다."),
 
     // 404 Not Found
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, false, "사용자를 찾을 수 없습니다."),
@@ -31,7 +32,8 @@ public enum ResponseCode {
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, false, "서버에 오류가 발생하였습니다."),
 
     // 200 OK
-
+    USER_LOGIN_SUCCESS(HttpStatus.OK, true, "사용자 로그인 성공"),
+    USER_TOKEN_REISSUE_SUCCESS(HttpStatus.OK, true, "사용자 토큰 재발급 성공"),
 
     // 201 Created
     USER_CREATE_SUCCESS(HttpStatus.CREATED, true, "사용자 생성 성공");

--- a/src/main/java/gdsc/cau/puangbe/user/entity/User.java
+++ b/src/main/java/gdsc/cau/puangbe/user/entity/User.java
@@ -1,17 +1,20 @@
 package gdsc.cau.puangbe.user.entity;
 
-import gdsc.cau.puangbe.common.enums.Gender;
 import gdsc.cau.puangbe.photo.entity.PhotoRequest;
 import gdsc.cau.puangbe.photo.entity.PhotoResult;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User {
 
     @Id
@@ -25,9 +28,23 @@ public class User {
 
     private LocalDateTime requestDate;
 
+    private String kakaoId;
+
     @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
     private List<PhotoResult> photoResult = new ArrayList<>();
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
     private List<PhotoRequest> photoRequest = new ArrayList<>();
+
+    @Builder
+    public User(String userName, LocalDateTime createDate, LocalDateTime requestDate, String kakaoId){
+        this.userName = userName;
+        this.createDate = createDate;
+        this.requestDate = requestDate;
+        this.kakaoId = kakaoId;
+    }
+
+    public void updateRequestDate(LocalDateTime requestDate){
+        this.requestDate = requestDate;
+    }
 }

--- a/src/main/java/gdsc/cau/puangbe/user/repository/UserRepository.java
+++ b/src/main/java/gdsc/cau/puangbe/user/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package gdsc.cau.puangbe.user.repository;
+
+import gdsc.cau.puangbe.user.entity.User;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+  Optional<User> findByKakaoId(String kakaoId);
+}


### PR DESCRIPTION
# #️⃣ 연관 이슈

> #6 

# 📝 작업 내용

> OIDC를 사용한 카카오 로그인
> JWT로 로그인 상태 유지
> 1. GET /auth/login/oauth/kakao
> 카카오 인가 코드로 카카오 토큰 발급 후 DB에 사용자 정보 저장
> JWT 발급하여 refresh token은 DB에 저장하고 access token 응답
> 2. GET /auth/reissue
> 프론트가 401을 받았을 때, 즉 요청의 authorization header에 담은 access token이 만료되었을 때 reissue 요청
> refresh token 검증 후 access token, refresh token 재발급

## 참고 이미지 및 자료
> 

# 💬 리뷰 요구사항

> 네이밍이나 접근 제한자 등이 잘못됐거나 더 좋은 의견이 있다면 말씀 부탁드립니다