### PR TITLE
[feat] Argument Resolver 적용 (#23)

### DIFF
--- a/src/main/java/gdsc/cau/puangbe/common/annotation/PuangUser.java
+++ b/src/main/java/gdsc/cau/puangbe/common/annotation/PuangUser.java
@@ -1,0 +1,11 @@
+package gdsc.cau.puangbe.common.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface PuangUser {
+}

--- a/src/main/java/gdsc/cau/puangbe/common/config/WebConfig.java
+++ b/src/main/java/gdsc/cau/puangbe/common/config/WebConfig.java
@@ -1,0 +1,20 @@
+package gdsc.cau.puangbe.common.config;
+
+import gdsc.cau.puangbe.common.config.resolver.PuangUserArgumentResolver;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+    private final PuangUserArgumentResolver puangUserArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(puangUserArgumentResolver);
+    }
+}

--- a/src/main/java/gdsc/cau/puangbe/common/config/resolver/PuangUserArgumentResolver.java
+++ b/src/main/java/gdsc/cau/puangbe/common/config/resolver/PuangUserArgumentResolver.java
@@ -1,0 +1,37 @@
+package gdsc.cau.puangbe.common.config.resolver;
+
+import gdsc.cau.puangbe.auth.external.JwtProvider;
+import gdsc.cau.puangbe.common.annotation.PuangUser;
+import gdsc.cau.puangbe.common.exception.AuthException;
+import gdsc.cau.puangbe.common.util.ResponseCode;
+import gdsc.cau.puangbe.user.entity.User;
+import gdsc.cau.puangbe.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+@RequiredArgsConstructor
+public class PuangUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final UserRepository userRepository;
+    private final JwtProvider jwtProvider;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(PuangUser.class) && parameter.getParameterType().equals(User.class);
+    }
+
+    @Override
+    public User resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        String accessToken = jwtProvider.getTokenFromAuthorizationHeader(webRequest.getHeader("Authorization"));
+        jwtProvider.validateToken(accessToken);
+        String kakaoId = jwtProvider.getKakaoIdFromToken(accessToken);
+        return userRepository.findByKakaoId(kakaoId)
+                .orElseThrow(() -> new AuthException(ResponseCode.UNAUTHORIZED));
+    }
+}


### PR DESCRIPTION
# #️⃣ 연관 이슈

> #23 

# 📝 작업 내용

> Argument Resolver를 적용하여 Authorization 헤더의 access_token을 User 객체로 바인딩하는 기능을 구현하였습니다.
> Controller 메서드의 파라미터에 (`@PuangUser User user`)를 추가하여 사용하시면 됩니다.

## 참고 이미지 및 자료

# 💬 리뷰 요구사항
