### PR TITLE
[infra] 배포 및 CI/CD 환경 구축 (#11)

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -1,0 +1,35 @@
+name: CD
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+    types: [closed]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    if: github.event.pull_request.merged == true
+    runs-on: self-hosted
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Docker Login
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Pull Docker Image
+        run: sudo docker pull ${{ secrets.DOCKERHUB_USERNAME }}/puang
+
+      - name: Remove Old Docker Container
+        run: sudo docker rm -f puang || true
+
+      - name: Run Updated Docker Container
+        run: sudo docker run -t -d --name puang -p 8080:8080 ${{ secrets.DOCKERHUB_USERNAME }}/puang

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,51 @@
+name: CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@ec92e829475ac0c2315ea8f9eced72db85bb337a # v3.0.0
+
+      - name: make application.yml
+        run: |
+          mkdir -p ./src/main/resources
+          cd ./src/main/resources
+          touch ./application.yml
+          touch ./application-prod.yml
+          echo "${{ secrets.APPLICATION }}" > ./application.yml
+          echo "${{ secrets.PROD }}" > ./application-prod.yml
+
+      - name: Build with Gradle
+        run: ./gradlew build -x test
+
+      - name: Docker Login
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Build Docker Image
+        run: docker build --platform linux/amd64 -t ${{ secrets.DOCKERHUB_USERNAME }}/puang .
+
+      - name: Push Docker Image
+        run: docker push ${{ secrets.DOCKERHUB_USERNAME }}/puang

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+# Use OpenJDK 17 as the base image
+FROM openjdk:17
+
+# Specify the build argument for the JAR file
+ARG JAR_FILE=build/libs/*.jar
+
+# Copy the JAR file into the container
+COPY ${JAR_FILE} app.jar
+
+# Set the entry point to run the JAR file
+ENTRYPOINT ["java", "-jar", "-Dspring.profiles.active=prod", "/app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -66,3 +66,7 @@ tasks.named('test') {
 bootJar {
 	archiveFileName = 'app.jar'
 }
+
+jar {
+	enabled = false
+}


### PR DESCRIPTION
# #️⃣ 연관 이슈

- #11

# 📝 작업 내용

> EC2에 서버를 배포하였고 CI/CD 파이프라인을 구축했습니다. 
> CI는 main으로 향하는 모든 PR 개방 시 적용되며, CD는 merged되었을 때만 동작하게 됩니다. 
> application-yml, application-prod.yml 등 환경변수 파일의 경우 Github Secrets에서 단일 값으로 관리합니다.
> swagger 정상 동작 역시 확인하였습니다. 다만 머지 후 정상 동작하는지는 검증이 필요합니다.

## 참고 이미지 및 자료
[[AWS] VPC로 Public/Private Subnet 설정](https://velog.io/@win-luck/AWS-VPC%EB%A1%9C-PublicPrivate-Subnet-%EC%84%A4%EC%A0%95%ED%95%98%EA%B8%B0)

# 💬 리뷰 요구사항
