### PR TITLE
[fix] 이미지 처리 요청 생성 api/photo-request return 값 변경(#31)

### DIFF
--- a/src/main/java/gdsc/cau/puangbe/photorequest/controller/PhotoRequestController.java
+++ b/src/main/java/gdsc/cau/puangbe/photorequest/controller/PhotoRequestController.java
@@ -30,9 +30,8 @@ public class PhotoRequestController {
             @ApiResponse(responseCode = "404", description = "유저를 찾지 못했을 때")
     })
     @PostMapping
-    public APIResponse<Void> createImage(@Parameter(hidden = true) @PuangUser User user, @RequestBody @Valid CreateImageDto dto) {
-        photoRequestService.createImage(dto, user.getId());
-        return APIResponse.success(null, ResponseCode.PHOTO_REQUEST_CREATE_SUCCESS.getMessage());
+    public APIResponse<Long> createImage(@Parameter(hidden = true) @PuangUser User user, @RequestBody @Valid CreateImageDto dto) {
+        return APIResponse.success(photoRequestService.createImage(dto, user.getId()), ResponseCode.PHOTO_REQUEST_CREATE_SUCCESS.getMessage());
     }
 
     // 유저의 전체 사진 리스트 조회

--- a/src/main/java/gdsc/cau/puangbe/photorequest/service/PhotoRequestService.java
+++ b/src/main/java/gdsc/cau/puangbe/photorequest/service/PhotoRequestService.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 public interface PhotoRequestService {
     //이미지 처리 요청 생성 (RabbitMQ호출)
-    void createImage(CreateImageDto dto, Long userId);
+    Long createImage(CreateImageDto dto, Long userId);
 
     //유저의 전체 사진 리스트 조회
     List<String> getRequestImages(Long userId);

--- a/src/main/java/gdsc/cau/puangbe/photorequest/service/PhotoRequestServiceImpl.java
+++ b/src/main/java/gdsc/cau/puangbe/photorequest/service/PhotoRequestServiceImpl.java
@@ -40,7 +40,7 @@ public class PhotoRequestServiceImpl implements PhotoRequestService {
     //이미지 처리 요청 생성 (RabbitMQ호출)
     @Override
     @Transactional
-    public void createImage(CreateImageDto dto, Long userId){
+    public Long createImage(CreateImageDto dto, Long userId){
         User user = userRepository.findById(userId).orElseThrow(() -> new BaseException(ResponseCode.USER_NOT_FOUND));
         // PhotoRequest 생성
         PhotoRequest request = PhotoRequest.builder()
@@ -80,6 +80,8 @@ public class PhotoRequestServiceImpl implements PhotoRequestService {
         // Redis에 userId 저장하고, userId로 requestId 추적할 수 있도록 함
         redisTemplate.opsForSet().add(ConstantUtil.USER_ID_KEY, userId);
         redisTemplate.opsForSet().add(userId.toString(), request.getId());
+
+        return request.getId();
     }
 
     // 유저의 전체 사진 리스트 조회


### PR DESCRIPTION
# #️⃣ 연관 이슈

- #31 

# 📝 작업 내용

> 유저 이미지 처리 요청을 생성하는 api/photo-request의 return값을 null에서 request-id로 변경하였습니다.

## 참고 이미지 및 자료
> swagger 이미지
![image](https://github.com/user-attachments/assets/dd3c1fba-251d-46b4-8783-901dd7417570)


# 💬 리뷰 요구사항
> 간단한 수정이니 빠른 merge 부탁드립니다.
(빠른 merge 가 되어야, 이후 redis 작업 담당하시는 분이 편할 것 같습니다..!!)
