### PR TITLE
[fix] RateLimiterInterceptor의 Authorization Header에 대한 Null 처리 (#39)

### DIFF
--- a/src/main/java/gdsc/cau/puangbe/common/interceptor/RateLimiterInterceptor.java
+++ b/src/main/java/gdsc/cau/puangbe/common/interceptor/RateLimiterInterceptor.java
@@ -29,7 +29,12 @@ public class RateLimiterInterceptor implements HandlerInterceptor {
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
         // key 생성 (kakaoId + API 엔트포인트)
-        String accessToken = jwtProvider.getTokenFromAuthorizationHeader(request.getHeader("Authorization"));
+        String authorizationHeader = request.getHeader("Authorization");
+        if (authorizationHeader == null) {
+            return true;
+        }
+
+        String accessToken = jwtProvider.getTokenFromAuthorizationHeader(authorizationHeader);
         String kakaoId = jwtProvider.getKakaoIdFromExpiredToken(accessToken);
         String servletPath = request.getServletPath();
         String key = kakaoId + servletPath;


### PR DESCRIPTION
# #️⃣ 연관 이슈

- #39 

# 📝 작업 내용

> /api/auth/login/oauth/kakao api를 위한 RateLimiterInterceptor의 Authorization Header Null 처리

## 참고 이미지 및 자료
> 

# 💬 리뷰 요구사항
