### PR TITLE
[refactor] findTopByUserIdOrderByCreateDateDesc 쿼리 성능 개선

### DIFF
--- a/src/main/java/gdsc/cau/puangbe/photo/repository/PhotoRequestRepository.java
+++ b/src/main/java/gdsc/cau/puangbe/photo/repository/PhotoRequestRepository.java
@@ -13,5 +13,5 @@ public interface PhotoRequestRepository extends JpaRepository<PhotoRequest, Long
     Optional<PhotoRequest> findById(Long photoRequestId);
     
     // 특정 유저의 최근에 만들어진 PhotoRequest 조회
-    Optional<PhotoRequest> findTopByUserIdOrderByCreateDateDesc(Long photoRequestId);
+    Optional<PhotoRequest> findTopByUserIdOrderByCreateDateDesc(Long userId);
 }


### PR DESCRIPTION
# 연관 이슈

- #49 

# 작업 내용

findTopByUserIdOrderByCreateDateDesc로 인한 조회 성능에 문제가 없는지 dummy data를 넣어 테스트했습니다. `select * from photo_request where user_id=? order by create_date desc limit 1;`에 대해 user를 1000명 생성하고, user마다 100번 요청을 생성했다고 (다소 극단적으로) 가정하고 진행했습니다.

<br>

### user_id 단일 칼럼 인덱스

조회 시 **Using filesort**가 발생합니다. user_id 1000으로 위 select 쿼리를 실행했을 때 100개의 요청을 가져오고, MySQL 내부에서 100개 요청을 정렬합니다.

<br>

### (user_id A, create_date A) 다중 칼럼 인덱스

조회 시 **Backward index scan**이 발생합니다. select 쿼리에서는 order by create_date DESC로 내림차순 정렬 결과를 원하는데 인덱스는 ASC로 오름차순 정렬되어 있어서 발생합니다.  관련해서 [MySQL Ascending index vs Descending index](https://tech.kakao.com/posts/351) 글을 참고했는데 읽어보시면 도움 될 것 같아요!
<br>

### (user_id A, create_date D) 다중 칼럼 인덱스

쿼리에서 요구하는대로 인덱스의 오름차순, 내림차순 정렬이 되어있기 때문에 인덱스가 목적대로 동작합니다. 

### 결론?

결론적으로 (user_id A, create_date D) 다중 칼럼 인덱스를 사용하면 정확히 findTopByUserIdOrderByCreateDateDesc에 대한 조회 쿼리 성능 향상에 도움이 될 수 있지만, 다음과 같은 이유로 인덱스를 적용하지 않는 것이 좋을 것 같아요!

1. **우리 서비스는 한 사람의 조회보다 여러 사람의 요청이 더 많이 발생하기 때문에 insert 성능을 포기할 수 없다.**
2. **현재 Using filesort가 발생하는 것이 나쁜 선택지가 아니다. user_id는 외래키로서 이미 인덱스로 관리되고 있기 때문에, user_id로 검색해서 나오는 데이터 (많아봐야) 5개에 대한 MySQL 메모리 상의 정렬은 쿼리 성능을 지나치게 저해하지 않는다.**

<br>

# 참고 자료

PR에 모든 과정과 결과를 담기에 무리가 있어 작업 내용에는  간단히 실험 결과, 결론만 작성했습니다. 각 케이스에 대한 자세한 내용은 [조회 성능을 위해 WHERE / ORDER BY 조건을 다중 칼럼 인덱스로 설정해도 될까?](https://rumoszin.github.io/posts/index-side-effect/) 이곳에서 확인할 수 있습니다.

# 리뷰 요구사항

코드 간단히 살펴봤는데, user_id로 where절 조건이 들어가는데 인터페이스에는 이름이 requestId로 적용되어 있어서 변경했습니다!
