### PR TITLE
[refactor] Facade 객체를 활용해 uploadPhoto 트랜잭션에서 이메일 전송 로직 분리

### DIFF
--- a/src/main/java/gdsc/cau/puangbe/auth/service/AuthServiceImpl.java
+++ b/src/main/java/gdsc/cau/puangbe/auth/service/AuthServiceImpl.java
@@ -14,6 +14,7 @@ import gdsc.cau.puangbe.common.util.ResponseCode;
 import gdsc.cau.puangbe.user.repository.UserRepository;
 import gdsc.cau.puangbe.user.entity.User;
 import io.jsonwebtoken.security.SignatureException;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
@@ -34,6 +35,7 @@ public class AuthServiceImpl implements AuthService {
     private final String ISS = "https://kauth.kakao.com";
 
     @Override
+    @Transactional
     public LoginResponse loginWithKakao(String code) {
         // 카카오 토큰 발급
         KakaoToken kakaoToken = kakaoProvider.getTokenByCode(code);

--- a/src/main/java/gdsc/cau/puangbe/photo/dto/request/EmailInfoDto.java
+++ b/src/main/java/gdsc/cau/puangbe/photo/dto/request/EmailInfoDto.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class EmailInfo {
+public class EmailInfoDto {
     String email;
     String name;
     String photoUrl;

--- a/src/main/java/gdsc/cau/puangbe/photo/service/PhotoServiceFacadeImpl.java
+++ b/src/main/java/gdsc/cau/puangbe/photo/service/PhotoServiceFacadeImpl.java
@@ -1,0 +1,73 @@
+package gdsc.cau.puangbe.photo.service;
+
+import gdsc.cau.puangbe.common.exception.BaseException;
+import gdsc.cau.puangbe.common.util.ConstantUtil;
+import gdsc.cau.puangbe.common.util.ResponseCode;
+import gdsc.cau.puangbe.photo.dto.request.EmailInfoDto;
+import gdsc.cau.puangbe.photo.entity.PhotoResult;
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.thymeleaf.TemplateEngine;
+import org.thymeleaf.context.Context;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class PhotoServiceFacadeImpl implements PhotoService{
+    private final PhotoServiceImpl photoServiceImpl;
+    private final JavaMailSender mailSender;
+    private final TemplateEngine templateEngine;
+
+    private final String EMAIL_LINK = "https://www.google.com/"; // TODO : 프론트 분들 링크 관련 답변 오면 프레임 페이지 링크 관련 수정
+
+    // 완성된 요청 id 및 imageUrl을 받아 저장
+    @Override
+    public void uploadPhoto(Long photoRequestId, String imageUrl) {
+        sendEmail(photoServiceImpl.uploadPhoto(photoRequestId, imageUrl));
+    }
+
+    // 특정 요청의 imageUrl 조회
+    @Override
+    @Transactional(readOnly = true)
+    public String getPhotoUrl(Long photoRequestId) {
+        PhotoResult photoResult = photoServiceImpl.getPhotoResult(photoRequestId);
+        if(photoResult.getImageUrl() == null){
+            throw new BaseException(ResponseCode.IMAGE_ON_PROCESS);
+        }
+
+        log.info("결과 이미지 URL 조회 완료: {}", photoResult.getImageUrl());
+        return photoResult.getImageUrl();
+    }
+
+    // 유저에게 이메일 전송
+    private void sendEmail(EmailInfoDto emailInfoDto) {
+        // 이메일 템플릿 내용 설정
+        Context context = new Context();
+        context.setVariable("userName", emailInfoDto.getName());
+        context.setVariable("photoUrl", emailInfoDto.getPhotoUrl());
+        context.setVariable("framePageUrl", EMAIL_LINK);
+        String body = templateEngine.process("email-template", context);
+
+        try {
+            // 메일 정보 설정
+            MimeMessage mimeMessage = mailSender.createMimeMessage();
+            MimeMessageHelper messageHelper = new MimeMessageHelper(mimeMessage, "UTF-8");
+            messageHelper.setFrom(ConstantUtil.GDSC_CAU_EMAIL);
+            messageHelper.setTo(emailInfoDto.getEmail());
+            messageHelper.setSubject("[푸앙이 사진관] AI 프로필 사진 생성 완료");
+            messageHelper.setText(body, true);
+
+            // 메일 전송
+            mailSender.send(mimeMessage);
+            log.info("이메일 전송 완료: {}", emailInfoDto.getEmail());
+        } catch (Exception e){
+            e.printStackTrace();
+            throw new BaseException(ResponseCode.EMAIL_SEND_ERROR);
+        }
+    }
+}

--- a/src/main/java/gdsc/cau/puangbe/photo/service/PhotoServiceImpl.java
+++ b/src/main/java/gdsc/cau/puangbe/photo/service/PhotoServiceImpl.java
@@ -4,38 +4,29 @@ import gdsc.cau.puangbe.common.enums.RequestStatus;
 import gdsc.cau.puangbe.common.exception.BaseException;
 import gdsc.cau.puangbe.common.util.ConstantUtil;
 import gdsc.cau.puangbe.common.util.ResponseCode;
-import gdsc.cau.puangbe.photo.dto.request.EmailInfo;
+import gdsc.cau.puangbe.photo.dto.request.EmailInfoDto;
 import gdsc.cau.puangbe.photo.entity.PhotoRequest;
 import gdsc.cau.puangbe.photo.entity.PhotoResult;
 import gdsc.cau.puangbe.photo.repository.PhotoResultRepository;
 import gdsc.cau.puangbe.photo.repository.PhotoRequestRepository;
 import gdsc.cau.puangbe.user.entity.User;
-import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.mail.javamail.JavaMailSender;
-import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.thymeleaf.TemplateEngine;
-import org.thymeleaf.context.Context;
 
 @Service
+@Transactional
 @RequiredArgsConstructor
 @Slf4j
-public class PhotoServiceImpl implements PhotoService {
+public class PhotoServiceImpl{
 
     private final PhotoResultRepository photoResultRepository;
     private final PhotoRequestRepository photoRequestRepository;
     private final RedisTemplate<String, Long> redisTemplate;
-    private final JavaMailSender mailSender;
-    private final TemplateEngine templateEngine;
 
-    // 완성된 요청 id 및 imageUrl을 받아 저장
-    @Override
-    @Transactional
-    public void uploadPhoto(Long photoRequestId, String imageUrl) {
+    public EmailInfoDto uploadPhoto(Long photoRequestId, String imageUrl) {
         PhotoRequest photoRequest = photoRequestRepository.findById(photoRequestId)
                 .orElseThrow(() -> new BaseException(ResponseCode.PHOTO_REQUEST_NOT_FOUND));
         if (photoRequest.getStatus() == RequestStatus.FINISHED) {
@@ -55,59 +46,15 @@ public class PhotoServiceImpl implements PhotoService {
         redisTemplate.delete(user.getId().toString());
         log.info("Redis 대기열에서 요청 삭제 : {}", user.getId());
 
-        // 이메일 발송
-        EmailInfo emailInfo = EmailInfo.builder()
+        // 이메일 DTO 만들어서 반환
+        return EmailInfoDto.builder()
                 .email(photoRequest.getEmail())
                 .photoUrl(imageUrl)
                 .name(user.getUserName())
-                .framePageUrl("https://www.google.com/") // TODO : 프론트 분들 링크 관련 답변 오면 프레임 페이지 링크 관련 수정
                 .build();
-
-        sendEmail(emailInfo);
     }
 
-    // 특정 요청의 imageUrl 조회
-    @Override
-    @Transactional(readOnly = true)
-    public String getPhotoUrl(Long photoRequestId) {
-        PhotoResult photoResult = getPhotoResult(photoRequestId);
-        if(photoResult.getImageUrl() == null){
-            throw new BaseException(ResponseCode.IMAGE_ON_PROCESS);
-        }
-
-        log.info("결과 이미지 URL 조회 완료: {}", photoResult.getImageUrl());
-        return photoResult.getImageUrl();
-    }
-
-    // 유저에게 이메일 전송
-    private void sendEmail(EmailInfo emailInfo) {
-        // 이메일 템플릿 내용 설정
-        Context context = new Context();
-        context.setVariable("userName", emailInfo.getName());
-        context.setVariable("photoUrl", emailInfo.getPhotoUrl());
-        context.setVariable("framePageUrl", emailInfo.getFramePageUrl());
-        String body = templateEngine.process("email-template", context);
-
-        try {
-            // 메일 정보 설정
-            MimeMessage mimeMessage = mailSender.createMimeMessage();
-            MimeMessageHelper messageHelper = new MimeMessageHelper(mimeMessage, "UTF-8");
-            messageHelper.setFrom(ConstantUtil.GDSC_CAU_EMAIL);
-            messageHelper.setTo(emailInfo.getEmail());
-            messageHelper.setSubject("[푸앙이 사진관] AI 프로필 사진 생성 완료");
-            messageHelper.setText(body, true);
-
-            // 메일 전송
-            mailSender.send(mimeMessage);
-            log.info("이메일 전송 완료: {}", emailInfo.getEmail());
-        } catch (Exception e){
-            e.printStackTrace();
-            throw new BaseException(ResponseCode.EMAIL_SEND_ERROR);
-        }
-
-    }
-
-    private PhotoResult getPhotoResult(Long photoRequestId){
+    public PhotoResult getPhotoResult(Long photoRequestId){
         return photoResultRepository.findByPhotoRequestId(photoRequestId)
                 .orElseThrow(() -> new BaseException(ResponseCode.PHOTO_RESULT_NOT_FOUND));
     }

--- a/src/main/java/gdsc/cau/puangbe/photo/service/PhotoServiceImpl.java
+++ b/src/main/java/gdsc/cau/puangbe/photo/service/PhotoServiceImpl.java
@@ -17,7 +17,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@Transactional
 @RequiredArgsConstructor
 @Slf4j
 public class PhotoServiceImpl{
@@ -26,6 +25,7 @@ public class PhotoServiceImpl{
     private final PhotoRequestRepository photoRequestRepository;
     private final RedisTemplate<String, Long> redisTemplate;
 
+    @Transactional
     public EmailInfoDto uploadPhoto(Long photoRequestId, String imageUrl) {
         PhotoRequest photoRequest = photoRequestRepository.findById(photoRequestId)
                 .orElseThrow(() -> new BaseException(ResponseCode.PHOTO_REQUEST_NOT_FOUND));
@@ -54,6 +54,7 @@ public class PhotoServiceImpl{
                 .build();
     }
 
+    @Transactional(readOnly = true)
     public PhotoResult getPhotoResult(Long photoRequestId){
         return photoResultRepository.findByPhotoRequestId(photoRequestId)
                 .orElseThrow(() -> new BaseException(ResponseCode.PHOTO_RESULT_NOT_FOUND));

--- a/src/test/java/gdsc/cau/puangbe/photo/service/PhotoServiceImplTest.java
+++ b/src/test/java/gdsc/cau/puangbe/photo/service/PhotoServiceImplTest.java
@@ -32,7 +32,7 @@ import static org.mockito.Mockito.*;
 class PhotoServiceImplTest {
 
     @InjectMocks
-    private PhotoServiceImpl photoService;
+    private PhotoServiceFacadeImpl photoService;
 
     @Mock
     private PhotoRequestRepository photoRequestRepository;


### PR DESCRIPTION
# 연관 이슈

- #51 

# 작업 내용

uploadPhoto 테스트를 진행할 때마다 sendEmail 메서드가 트랜잭션에 포함되어 있어 병목이 발생합니다. @ExeTimer AOP로 실행 시간을 측정한 결과 약 4.5초가 소요됩니다. 이메일 전송을 할 수 없는 상황일 때 uploadPhoto가 아예 안되어버리는 엄청난 일이 발생할 수 있기 때문에 Facade 객체를 앞 단에 두어 트랜잭션에서 분리했습니다.

트랜잭션의 범위가 정확히 레포지토리로 한정되었고, 병목인 로직을 분리하여 한 쓰레드가 트랜잭션을 오래 붙잡지 않습니다! uploadPhoto 테스트도 1.2초 내로 완료됩니다.

### 작업 전
![image](https://github.com/user-attachments/assets/72879ad9-ad87-4359-93d3-f5d134bef8f7)

<br>

### 작업 후
![image](https://github.com/user-attachments/assets/a048fbf8-42b1-4f3d-bd56-af75ced3f9ed)



# 참고

Real MySQL 5.1.2 트랜잭션 주의사항을 참고하였습니다.



